### PR TITLE
Add validation annotation for phone number and email

### DIFF
--- a/server/src/main/java/org/example/backend/domain/Student.java
+++ b/server/src/main/java/org/example/backend/domain/Student.java
@@ -1,7 +1,18 @@
 package org.example.backend.domain;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.example.backend.common.Auditable;
 
 import java.time.LocalDate;

--- a/server/src/main/java/org/example/backend/dto/request/StudentRequest.java
+++ b/server/src/main/java/org/example/backend/dto/request/StudentRequest.java
@@ -2,10 +2,11 @@ package org.example.backend.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
-import org.example.backend.validator.ValidStudentStatusTransition;
+import org.example.backend.validator.EmailDomain;
+import org.example.backend.validator.PhoneNumber;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -19,7 +20,7 @@ public class StudentRequest {
     @NotBlank(message = "Full name is required")
     private String fullName;
 
-    @NotBlank(message = "Date of birth is required")
+    @NotNull(message = "Date of birth is required")
     private LocalDate dob;
 
     @NotBlank(message = "Gender is required")
@@ -30,22 +31,23 @@ public class StudentRequest {
 
     @NotBlank(message = "Email is required")
     @Email(message = "Email should be valid")
+    @EmailDomain
     private String email;
 
     @NotBlank(message = "Phone number is required")
-    @Pattern(regexp = "^(0[0-9]{9})$", message = "Số điện thoại không hợp lệ")
+    @PhoneNumber
     private String phone;
 
     @NotBlank(message = "Nationality is required")
     private String nationality;
 
-    @NotBlank(message = "Faculty id is required")
+    @NotNull(message = "Faculty id is required")
     private Integer facultyId;
 
-    @NotBlank(message = "Program id is required")
+    @NotNull(message = "Program id is required")
     private Integer programId;
 
-    @NotBlank(message = "Student status id is required")
+    @NotNull(message = "Student status id is required")
     private Integer studentStatusId;
 
     private List<AddressRequest> addresses;

--- a/server/src/main/java/org/example/backend/dto/request/StudentUpdateRequest.java
+++ b/server/src/main/java/org/example/backend/dto/request/StudentUpdateRequest.java
@@ -4,10 +4,10 @@ package org.example.backend.dto.request;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
+import org.example.backend.validator.EmailDomain;
+import org.example.backend.validator.PhoneNumber;
 import org.example.backend.validator.ValidStudentStatusTransition;
 
 import java.time.LocalDate;
@@ -29,10 +29,8 @@ public class StudentUpdateRequest {
 
     private String intake;
 
-    @Email(message = "Email should be valid")
     private String email;
 
-    @Pattern(regexp = "^(0[0-9]{9})$", message = "Số điện thoại không hợp lệ")
     private String phone;
 
     private String nationality;

--- a/server/src/main/java/org/example/backend/service/impl/StudentServiceImpl.java
+++ b/server/src/main/java/org/example/backend/service/impl/StudentServiceImpl.java
@@ -3,11 +3,10 @@ package org.example.backend.service.impl;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.poi.sl.draw.geom.GuideIf;
-import org.example.backend.domain.Program;
 import org.example.backend.domain.Address;
 import org.example.backend.domain.Document;
 import org.example.backend.domain.Faculty;
+import org.example.backend.domain.Program;
 import org.example.backend.domain.Student;
 import org.example.backend.domain.StudentStatus;
 import org.example.backend.dto.request.StudentRequest;
@@ -16,8 +15,8 @@ import org.example.backend.dto.response.StudentResponse;
 import org.example.backend.mapper.AddressMapper;
 import org.example.backend.mapper.DocumentMapper;
 import org.example.backend.mapper.StudentMapper;
-import org.example.backend.repository.IProgramRepository;
 import org.example.backend.repository.IFacultyRepository;
+import org.example.backend.repository.IProgramRepository;
 import org.example.backend.repository.IStudentRepository;
 import org.example.backend.repository.IStudentStatusRepository;
 import org.example.backend.service.IStudentService;
@@ -50,6 +49,11 @@ public class StudentServiceImpl implements IStudentService {
     @Override
     @Transactional
     public StudentResponse addStudent(StudentRequest request) {
+        if (studentRepository.findByStudentId(request.getStudentId()).isPresent()) {
+            log.error("Student id {} already exists", request.getStudentId());
+            throw new RuntimeException("Student id already exists");
+        }
+
         Faculty faculty = facultyRepository.findById(request.getFacultyId()).orElseThrow(() -> new RuntimeException("Faculty not found"));
         Program program = programRepository.findById(request.getProgramId()).orElseThrow(() -> new RuntimeException("Program not found"));
         StudentStatus studentStatus = studentStatusRepository.findById(request.getStudentStatusId()).orElseThrow(() -> new RuntimeException("Student status not found"));

--- a/server/src/main/java/org/example/backend/validator/EmailDomain.java
+++ b/server/src/main/java/org/example/backend/validator/EmailDomain.java
@@ -1,0 +1,18 @@
+package org.example.backend.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = EmailDomainValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EmailDomain {
+    String message() default "Invalid email domain";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/server/src/main/java/org/example/backend/validator/EmailDomainValidator.java
+++ b/server/src/main/java/org/example/backend/validator/EmailDomainValidator.java
@@ -1,0 +1,21 @@
+package org.example.backend.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EmailDomainValidator implements ConstraintValidator<EmailDomain, String> {
+    private static final String[] ALLOWED_DOMAINS = {"example.com", "student.university.edu.vn"};
+
+    @Override
+    public boolean isValid(String email, ConstraintValidatorContext context) {
+        if (email == null) {
+            return true;
+        }
+        for (String domain : ALLOWED_DOMAINS) {
+            if (email.endsWith(domain)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/server/src/main/java/org/example/backend/validator/PhoneNumber.java
+++ b/server/src/main/java/org/example/backend/validator/PhoneNumber.java
@@ -1,0 +1,18 @@
+package org.example.backend.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = PhoneNumberValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PhoneNumber {
+    String message() default "Invalid phone number";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/server/src/main/java/org/example/backend/validator/PhoneNumberValidator.java
+++ b/server/src/main/java/org/example/backend/validator/PhoneNumberValidator.java
@@ -1,0 +1,17 @@
+package org.example.backend.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PhoneNumberValidator implements ConstraintValidator<PhoneNumber, String> {
+    private static final String PHONE_NUMBER_CODE = "+84";
+
+    @Override
+    public boolean isValid(String phone, ConstraintValidatorContext context) {
+        if (phone == null) {
+            return true;
+        }
+
+        return phone.startsWith(PHONE_NUMBER_CODE);
+    }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -11,14 +11,18 @@ server:
   port: 9000
 
 jpa:
+  hibernate:
+    ddl-auto: validate
+  properties:
     hibernate:
-        ddl-auto: validate
-    properties:
-        hibernate:
-            dialect: org.hibernate.dialect.PostgreSQLDialect
-            format_sql: true
-            show_sql: true
-            use_sql_comments: true
+      dialect: org.hibernate.dialect.PostgreSQLDialect
+      use_sql_comments: true
+
+logging:
+  level:
+    org.springframework: INFO
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
 
 cors:
     allowed-origins: "http://localhost:3000"


### PR DESCRIPTION
1. Student ID uniqueness validation to prevent duplicates during create operations

2. Added configurable validation for:
- Email domain restrictions (e.g., @student.university.edu.vn)
- Country-specific phone number formats (e.g., Vietnam: +84)

3. Enhanced logging configuration in application.yml