### PR TITLE
fix: course api integration

### DIFF
--- a/client/src/app/course-management/actions/CourseActions.ts
+++ b/client/src/app/course-management/actions/CourseActions.ts
@@ -1,5 +1,5 @@
 import { message } from 'antd';
-import { Course } from '../../../interfaces/CourseResponse';
+import { Course } from '../../../interfaces/Course';
 
 export const addCourse = (courses: Course[], newCourse: Course): Course[] => {
   return [...courses, newCourse];

--- a/client/src/app/course-management/components/CourseModal.tsx
+++ b/client/src/app/course-management/components/CourseModal.tsx
@@ -2,7 +2,7 @@
 
 import { Form, Input, Modal, Button, Select, message, Switch, Spin } from 'antd';
 import { useEffect, useState } from 'react';
-import { Course } from '../../../interfaces/CourseResponse';
+import { Course } from '../../../interfaces/Course';
 import { useFaculties } from '@/libs/hooks/useReferences';
 
 const { Option } = Select;
@@ -42,7 +42,7 @@ const renderOptions = (options?: { key: number; value: string; label: string }[]
       courseForm.setFieldsValue(course);
       setIsEdit(true);
     } else {
-      courseForm.resetFields();
+      // courseForm.resetFields();
       setIsEdit(false);
     }
   }, [course, courseForm]);
@@ -124,7 +124,7 @@ const renderOptions = (options?: { key: number; value: string; label: string }[]
         <Form.Item label="Học phần tiên quyết" name="prerequisiteCourseId">
           <Select placeholder="Chọn học phần tiên quyết" allowClear>
             {allCourses
-              .filter((c) => !course || c.courseId !== course.courseId)
+              .filter((c) => c.courseId && (!course || c.courseId !== course.courseId))
               .map((c) => (
                 <Option key={c.courseId} value={c.courseId}>
                   {c.courseCode} - {c.courseName}

--- a/client/src/app/course-management/components/CourseTable.tsx
+++ b/client/src/app/course-management/components/CourseTable.tsx
@@ -3,7 +3,7 @@ import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { useEffect, useState } from 'react';
 import { SortOrder } from 'antd/es/table/interface';
 import { fetchReference } from '@/libs/services/referenceService';
-import { Course } from '@/interfaces/CourseResponse';
+import { Course } from '@/interfaces/Course';
 interface CourseTableProps {
   courses: Course[];
   onEdit: (course: Course) => void;
@@ -56,8 +56,8 @@ const CourseTable = ({ courses, onEdit, onDelete, openModal, loading }: CourseTa
         { title: 'Số tín chỉ', dataIndex: 'credits' },
         {
             title: 'Khoa',
-            dataIndex: 'facultyId',
-            render: (facultyId: number) => facultyMap[facultyId] || 'Không xác định',
+            dataIndex: 'faculty',
+            // render: (facultyId: number) => facultyMap[facultyId] || 'Không xác định',
         },
         {
             title: 'Học phần tiên quyết',
@@ -123,7 +123,7 @@ const CourseTable = ({ courses, onEdit, onDelete, openModal, loading }: CourseTa
            <Table
     columns={columns}
     dataSource={filteredCourses}
-    rowKey='id'
+    rowKey='courseCode'
     pagination={{
         pageSize: 10,
         showSizeChanger: false,

--- a/client/src/app/course-management/components/Home.tsx
+++ b/client/src/app/course-management/components/Home.tsx
@@ -5,7 +5,7 @@ import { Button, message } from 'antd';
 import { PlusOutlined, UploadOutlined, DownloadOutlined } from '@ant-design/icons';
 import CourseTable from './CourseTable';
 import CourseModal from './CourseModal';
-import { Course } from '@/interfaces/CourseResponse';
+import { Course } from '@/interfaces/Course';
 import {
   updateCourse as updateCourseState,
   addCourse as addCourseState,

--- a/client/src/app/course-management/page.tsx
+++ b/client/src/app/course-management/page.tsx
@@ -9,5 +9,26 @@ export default function CourseManagementPage() {
     if (isLoading) return <div>Đang tải dữ liệu khóa học...</div>;
     if (error) return <div>Lỗi khi tải khóa học</div>;
 
-    return <CoursePage initialCourses={courses || []} />;
+    return (
+        <CoursePage
+            initialCourses={
+                courses?.map((course: any) => ({
+                    courseId: course.courseId,
+                    courseCode: course.courseCode,
+                    courseName: course.courseName,
+                    credits: course.credits,
+                    faculty: course.faculty,
+                    description: course.description,
+                    prerequisiteCourseId: course.prerequisiteCourseId,
+                    isActive: course.isActive,
+                    facultyId: course.facultyId || null,
+                    createdAt: course.createdAt || null,
+                    updatedAt: course.updatedAt || null,
+                    deleted: course.deleted || false,
+                    createdBy: course.createdBy || null,
+                    updatedBy: course.updatedBy || null,
+                })) || []
+            }
+        />
+    );
 }

--- a/client/src/interfaces/Course.ts
+++ b/client/src/interfaces/Course.ts
@@ -1,0 +1,5 @@
+import { CourseResponse } from "./CourseResponse";
+
+export interface Course extends CourseResponse {
+    faculty: string;
+}

--- a/client/src/interfaces/CourseResponse.ts
+++ b/client/src/interfaces/CourseResponse.ts
@@ -1,9 +1,9 @@
-export interface Course {
+export interface CourseResponse {
   courseId: number; 
   courseCode: string; 
   courseName: string; 
   credits: number; 
-  facultyId?: number | null; 
+  facultyId: number; 
   description?: string | null;
   prerequisiteCourseId?: number | null; 
   isActive: boolean; 
@@ -13,4 +13,3 @@ export interface Course {
   createdBy: string; 
   updatedBy: string; 
 }
-

--- a/client/src/interfaces/CreateCourseRequest.ts
+++ b/client/src/interfaces/CreateCourseRequest.ts
@@ -2,7 +2,7 @@ export interface CreateCourseRequest {
   courseCode: string;
   courseName: string;
   credits: number;
-  facultyId?: number | null;
+  facultyId: number;
   description?: string | null;
   prerequisiteCourseId?: number | null;
   isActive: boolean;

--- a/client/src/interfaces/UpdateCourseRequest.ts
+++ b/client/src/interfaces/UpdateCourseRequest.ts
@@ -1,4 +1,5 @@
 export interface UpdateCourseRequest {
+  courseId: number;
   courseCode?: string;
   courseName?: string;
   credits?: number;

--- a/client/src/libs/api/courseApi.ts
+++ b/client/src/libs/api/courseApi.ts
@@ -1,4 +1,4 @@
-import { Course } from '@/interfaces/CourseResponse';
+import { Course } from '@/interfaces/Course';
 import { CreateCourseRequest } from '@/interfaces/CreateCourseRequest';
 import { UpdateCourseRequest } from '@/interfaces/UpdateCourseRequest';
 import api from './api';
@@ -12,7 +12,7 @@ export const getCourses = async () => {
     }
 };
 
-export const postCourse = async (course: Partial<CreateCourseRequest>) => {
+export const postCourse = async (course: CreateCourseRequest) => { // do phải POST toàn bộ dữ liệu (trừ description?, prerequisiteCourseId?) nên không dùng Paritial nha
     try {
         const response = await api.post(`/courses`, course);
         return response.data;

--- a/client/src/libs/services/courseService.ts
+++ b/client/src/libs/services/courseService.ts
@@ -1,4 +1,5 @@
-import { Course } from '@/interfaces/CourseResponse';
+import { Course } from '@/interfaces/Course';
+import { CreateCourseRequest } from '@/interfaces/CreateCourseRequest';
 import {
   getCourses,
   postCourse,
@@ -6,17 +7,20 @@ import {
   deleteCourse
 } from '@/libs/api/courseApi';
 import { cleanData } from '@/libs/utils/cleanData';
+import { transformCourseToPostRequest } from '@/libs/utils/courseTransform';
+import { transformCourseToGetResponse } from '@/libs/utils/courseTransform';
 
-export const fetchCourses = async (): Promise<Course[]> => {
+export const fetchCourses = async () => {
   try {
-    return await getCourses(); // Không cần map transform nữa
+    const response = await getCourses();
+    return response.map(transformCourseToGetResponse);
   } catch (error) {
     throw error;
   }
 };
 
 export const createCourse = async (value: Course) => {
-  const requestData = cleanData(value); // Dùng object Course trực tiếp
+  const requestData = transformCourseToPostRequest(value); // Dùng object Course trực tiếp
   try {
     const data = await postCourse(requestData);
     return data;

--- a/client/src/libs/utils/courseTransform.ts
+++ b/client/src/libs/utils/courseTransform.ts
@@ -1,0 +1,50 @@
+import { Course } from "@/interfaces/Course";
+import { CreateCourseRequest } from "@/interfaces/CreateCourseRequest";
+import { UpdateCourseRequest } from "@/interfaces/UpdateCourseRequest";
+import useReferenceStore from '@/libs/stores/referenceStore';
+
+export const transformCourseToGetResponse = (response: any) => {
+    return {
+        courseId: response.courseId,
+        courseCode: response.courseCode,
+        courseName: response.courseName,
+        credits: response.credits,
+        faculty: response.facultyName,
+        description: response.description,
+        prerequisiteCourseId: response.prerequisiteCourseId,
+        isActive: response.isActive,
+    }
+}
+
+export const transformCourseToPostRequest = (request: Course): CreateCourseRequest => {
+    const { faculties } = useReferenceStore.getState();
+    const faculty = faculties.find((faculty: any) => faculty.facultyName === request.faculty);
+    const facultyId = faculty ? faculty.id : 1;
+
+    return {
+        courseCode: request.courseCode,
+        courseName: request.courseName,
+        credits: request.credits,
+        facultyId: facultyId,
+        description: request.description || null,
+        prerequisiteCourseId: request.prerequisiteCourseId || null,
+        isActive: request.isActive,
+    };
+}
+
+export const transformCourseToPatchRequest = (request: Course): Partial<UpdateCourseRequest> => {
+    const { faculties } = useReferenceStore.getState();
+    const faculty = faculties.find((faculty: any) => faculty.facultyName === request.faculty);
+    const facultyId = faculty ? faculty.id : 1;
+
+    return {
+        courseId: request.courseId,
+        courseCode: request.courseCode,
+        courseName: request.courseName,
+        credits: request.credits,
+        facultyId: facultyId,
+        description: request.description || null,
+        prerequisiteCourseId: request.prerequisiteCourseId || null,
+        isActive: request.isActive,
+    };
+}


### PR DESCRIPTION
Giải thích nôm na nha @TaiVo030104

Khi fetch API để lấy dữ liệu để hiển thị UI, thì phải qua transform để xử lý lại interface cho phù hợp với UI. Và ngược lại, khi thực hiện một action (create, update) cũng phải qua transform để xử lý lại interface cho phù hợp để gửi đi. Tức là, mình sẽ có 4 interface chính là: Course, CourseReponse, CreateCourseRequest, UpdateCourseRequest.

Flow:
- Khi yêu cầu fetch API: API (thuộc kiểu CourseReponse[]) -> Qua Transform -> Data (thuộc kiểu Course[]) -> Hiển thị lên UI
- Khi thực hiện action: onClick() -> Data (thuộc kiểu Course[]) -> Qua Transform -> API (thuộc kiểu CreateCourseRequest[] / UpdateCourseRequest[])

Nghĩa là về cơ bản thì tầng UI không phải xử lý gì về dữ liệu cả. Ví dụ như cần hiển thị Faculty nhưng mà API lại chỉ trả ra FacultyId => Mình sẽ xử lý chỗ Transform. Hay ví dụ như, cần gửi một Course mới, Course lúc nhập vào chỉ là Name thôi chứ không phải Id => Mình cũng sẽ map Name sang Id chỗ Transform.

Lúc đầu t chạy chương trình thì error nó báo "must have faculty id" là do request thiếu faculty id, do m chỉ truyền faculty name á nên server backend không nhận. Nói chung là m code oke r :v, do bug này nó hơi khó nói, phải sửa lặt vặt nhiều chỗ nên hôm qua t merge luôn r fix lại xíu thôi :>