### PR TITLE
Add Multi-language Support Using Translations Table

### DIFF
--- a/server/src/main/java/org/example/backend/common/LanguageInterceptor.java
+++ b/server/src/main/java/org/example/backend/common/LanguageInterceptor.java
@@ -1,0 +1,33 @@
+package org.example.backend.common;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class LanguageInterceptor implements HandlerInterceptor {
+    public static final ThreadLocal<String> CURRENT_LANGUAGE = new ThreadLocal<>();
+    public static final String DEFAULT_LANGUAGE = "vi";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String language = request.getHeader("Accept-Language");
+        if (language == null || language.isEmpty()) {
+            language = DEFAULT_LANGUAGE;
+        }
+
+        if (!language.equals("en") && !language.equals("vi")) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return false;
+        }
+
+        CURRENT_LANGUAGE.set(language);
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        CURRENT_LANGUAGE.remove();
+    }
+}

--- a/server/src/main/java/org/example/backend/config/WebConfig.java
+++ b/server/src/main/java/org/example/backend/config/WebConfig.java
@@ -1,0 +1,21 @@
+package org.example.backend.config;
+
+import org.example.backend.common.LanguageInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final LanguageInterceptor languageInterceptor;
+
+    public WebConfig(@Autowired LanguageInterceptor languageInterceptor) {
+        this.languageInterceptor = languageInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(languageInterceptor);
+    }
+}

--- a/server/src/main/java/org/example/backend/domain/Translation.java
+++ b/server/src/main/java/org/example/backend/domain/Translation.java
@@ -1,0 +1,32 @@
+package org.example.backend.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.example.backend.common.Auditable;
+
+@Entity
+@Table(name = "translations")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Translation extends Auditable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String entityType;
+    private Integer entityId;
+    private String fieldName;
+    private String languageCode;
+    private String translatedValue;
+}

--- a/server/src/main/java/org/example/backend/mapper/AddressMapper.java
+++ b/server/src/main/java/org/example/backend/mapper/AddressMapper.java
@@ -5,6 +5,8 @@ import org.example.backend.dto.request.AddressRequest;
 import org.example.backend.dto.response.AddressResponse;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
 public class AddressMapper {
     public static Address mapToDomain(AddressRequest addressRequest) {
@@ -26,6 +28,20 @@ public class AddressMapper {
                 .district(address.getDistrict())
                 .cityProvince(address.getCityProvince())
                 .country(address.getCountry())
+                .build();
+    }
+
+    public static AddressResponse mapToResponseWithTranslation(
+            Address address,
+            Map<String, String> translations) {
+
+        return AddressResponse.builder()
+                .addressType(translations.getOrDefault("addressType", address.getAddressType()))
+                .houseNumberStreetName(address.getHouseNumberStreetName())
+                .wardCommune(translations.getOrDefault("wardCommune", address.getWardCommune()))
+                .district(translations.getOrDefault("district", address.getDistrict()))
+                .cityProvince(translations.getOrDefault("cityProvince", address.getCityProvince()))
+                .country(translations.getOrDefault("country", address.getCountry()))
                 .build();
     }
 }

--- a/server/src/main/java/org/example/backend/mapper/ClassMapper.java
+++ b/server/src/main/java/org/example/backend/mapper/ClassMapper.java
@@ -6,6 +6,8 @@ import org.example.backend.dto.response.ClassResponse;
 import org.example.backend.dto.response.ClassSummaryResponse;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
 public class ClassMapper {
     public static ClassSummaryResponse mapFromDomainToClassSummaryResponse(Class aClass) {
@@ -13,6 +15,15 @@ public class ClassMapper {
                 .classCode(aClass.getClassCode())
                 .maxStudents(aClass.getMaxStudents())
                 .schedule(aClass.getSchedule())
+                .room(aClass.getRoom())
+                .build();
+    }
+
+    public static ClassSummaryResponse mapFromDomainToClassSummaryResponseWithTranslation(Class aClass, Map<String, String> translation) {
+        return ClassSummaryResponse.builder()
+                .classCode(aClass.getClassCode())
+                .maxStudents(aClass.getMaxStudents())
+                .schedule(translation.getOrDefault("schedule", aClass.getSchedule()))
                 .room(aClass.getRoom())
                 .build();
     }
@@ -40,6 +51,39 @@ public class ClassMapper {
                 .facultyName(aClass.getCourse().getFaculty().getFacultyName())
                 .prerequisiteCourseCode(aClass.getCourse().getPrerequisiteCourse() != null ? aClass.getCourse().getPrerequisiteCourse().getCourseCode() : null)
                 .prerequisiteCourseName(aClass.getCourse().getPrerequisiteCourse() != null ? aClass.getCourse().getPrerequisiteCourse().getCourseName() : null)
+                .lecturerId(aClass.getLecturer().getId())
+                .lecturerName(aClass.getLecturer().getFullName())
+                .semesterId(aClass.getSemester().getId())
+                .semesterName(aClass.getSemester().getSemester())
+                .createdDate(aClass.getCreatedAt())
+                .updatedDate(aClass.getUpdatedAt())
+                .createdBy(aClass.getCreatedBy())
+                .updatedBy(aClass.getUpdatedBy())
+                .build();
+    }
+
+    public static ClassResponse mapFromDomainToClassResponseWithTranslation(
+            Class aClass,
+            Map<String, String> classTranslations,
+            Map<String, String> courseTranslations,
+            Map<String, String> facultyTranslations,
+            Map<String, String> prerequisiteCourseTranslations) {
+
+        return ClassResponse.builder()
+                .id(aClass.getId())
+                .classCode(aClass.getClassCode())
+                .maxStudents(aClass.getMaxStudents())
+                .schedule(classTranslations.getOrDefault("schedule", aClass.getSchedule()))
+                .room(aClass.getRoom())
+                .courseId(aClass.getCourse().getId())
+                .courseCode(aClass.getCourse().getCourseCode())
+                .courseName(courseTranslations.getOrDefault("courseName", aClass.getCourse().getCourseName()))
+                .credits(aClass.getCourse().getCredits())
+                .facultyName(facultyTranslations.getOrDefault("facultyName", aClass.getCourse().getFaculty().getFacultyName()))
+                .prerequisiteCourseCode(aClass.getCourse().getPrerequisiteCourse() != null ? aClass.getCourse().getPrerequisiteCourse().getCourseCode() : null)
+                .prerequisiteCourseName(aClass.getCourse().getPrerequisiteCourse() != null ?
+                        prerequisiteCourseTranslations.getOrDefault("courseName", aClass.getCourse().getPrerequisiteCourse().getCourseName()) :
+                        null)
                 .lecturerId(aClass.getLecturer().getId())
                 .lecturerName(aClass.getLecturer().getFullName())
                 .semesterId(aClass.getSemester().getId())

--- a/server/src/main/java/org/example/backend/mapper/CourseMapper.java
+++ b/server/src/main/java/org/example/backend/mapper/CourseMapper.java
@@ -1,10 +1,11 @@
 package org.example.backend.mapper;
 
 import org.example.backend.domain.Course;
-import org.example.backend.domain.Faculty;
 import org.example.backend.dto.request.CourseRequest;
 import org.example.backend.dto.response.CourseResponse;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
 
 @Component
 public class CourseMapper {
@@ -21,6 +22,32 @@ public class CourseMapper {
                 .facultyName(course.getFaculty().getFacultyName())
                 .prerequisiteCourseId(course.getPrerequisiteCourse() != null ? course.getPrerequisiteCourse().getId() : null)
                 .prerequisiteCourseName(course.getPrerequisiteCourse() != null ? course.getPrerequisiteCourse().getCourseName() : null)
+                .createdAt(course.getCreatedAt())
+                .updatedAt(course.getUpdatedAt())
+                .createdBy(course.getCreatedBy())
+                .updatedBy(course.getUpdatedBy())
+                .build();
+    }
+
+    public static CourseResponse mapFromCourseDomainToCourseResponseWithTranslation(
+            Course course,
+            Map<String, String> courseTranslations,
+            Map<String, String> facultyTranslations,
+            Map<String, String> prerequisiteCourseTranslations) {
+
+        return CourseResponse.builder()
+                .courseId(course.getId())
+                .courseCode(course.getCourseCode())
+                .courseName(courseTranslations.getOrDefault("courseName", course.getCourseName()))
+                .credits(course.getCredits())
+                .description(courseTranslations.getOrDefault("description", course.getDescription()))
+                .isActive(course.getIsActive())
+                .facultyId(course.getFaculty().getId())
+                .facultyName(facultyTranslations.getOrDefault("facultyName", course.getFaculty().getFacultyName()))
+                .prerequisiteCourseId(course.getPrerequisiteCourse() != null ? course.getPrerequisiteCourse().getId() : null)
+                .prerequisiteCourseName(course.getPrerequisiteCourse() != null ?
+                        prerequisiteCourseTranslations.getOrDefault("courseName", course.getPrerequisiteCourse().getCourseName()) :
+                        null)
                 .createdAt(course.getCreatedAt())
                 .updatedAt(course.getUpdatedAt())
                 .createdBy(course.getCreatedBy())

--- a/server/src/main/java/org/example/backend/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/example/backend/mapper/DocumentMapper.java
@@ -5,6 +5,8 @@ import org.example.backend.dto.request.DocumentRequest;
 import org.example.backend.dto.response.DocumentResponse;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
 public class DocumentMapper {
     public static Document mapToDomain(DocumentRequest documentRequest) {
@@ -29,6 +31,22 @@ public class DocumentMapper {
                 .issuedBy(document.getIssuedBy())
                 .issuedCountry(document.getIssuedCountry())
                 .note(document.getNote())
+                .hasChip(document.getHasChip())
+                .build();
+    }
+
+    public static DocumentResponse mapToResponseWithTranslation(
+            Document document,
+            Map<String, String> translations) {
+
+        return DocumentResponse.builder()
+                .documentType(translations.getOrDefault("documentType", document.getDocumentType()))
+                .documentNumber(document.getDocumentNumber())
+                .issuedDate(document.getIssuedDate())
+                .expiredDate(document.getExpiredDate())
+                .issuedBy(translations.getOrDefault("issuedBy", document.getIssuedBy()))
+                .issuedCountry(document.getIssuedCountry())
+                .note(translations.getOrDefault("note", document.getNote()))
                 .hasChip(document.getHasChip())
                 .build();
     }

--- a/server/src/main/java/org/example/backend/mapper/FacultyMapper.java
+++ b/server/src/main/java/org/example/backend/mapper/FacultyMapper.java
@@ -3,7 +3,11 @@ package org.example.backend.mapper;
 import org.example.backend.domain.Faculty;
 import org.example.backend.dto.request.FacultyRequest;
 import org.example.backend.dto.response.FacultyResponse;
+import org.example.backend.dto.response.StudentResponse;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class FacultyMapper {
@@ -18,6 +22,41 @@ public class FacultyMapper {
                 .id(faculty.getId())
                 .facultyName(faculty.getFacultyName())
                 .students(faculty.getStudents() != null ? faculty.getStudents().stream().map(StudentMapper::mapToResponse).collect(Collectors.toList()) : null)
+                .createdAt(faculty.getCreatedAt())
+                .updatedAt(faculty.getUpdatedAt())
+                .createdBy(faculty.getCreatedBy())
+                .updatedBy(faculty.getUpdatedBy())
+                .build();
+    }
+
+    public static FacultyResponse mapToResponseWithTranslation(
+            Faculty faculty,
+            Map<String, String> facultyTranslations,
+            Map<Integer, Map<String, String>> studentTranslations) {
+
+        List<StudentResponse> studentResponses = null;
+        if (faculty.getStudents() != null) {
+            studentResponses = faculty.getStudents().stream()
+                    .map(student -> {
+                        Map<String, String> studentTrans = studentTranslations.getOrDefault(Integer.parseInt(student.getStudentId().replaceAll("[^\\d]", "")), Collections.emptyMap());
+
+                        return StudentMapper.mapToResponseWithTranslation(
+                                student,
+                                studentTrans,
+                                Collections.emptyMap(),
+                                Collections.emptyMap(),
+                                Collections.emptyMap(),
+                                Collections.emptyMap(),
+                                Collections.emptyMap()
+                        );
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        return FacultyResponse.builder()
+                .id(faculty.getId())
+                .facultyName(facultyTranslations.getOrDefault("facultyName", faculty.getFacultyName()))
+                .students(studentResponses)
                 .createdAt(faculty.getCreatedAt())
                 .updatedAt(faculty.getUpdatedAt())
                 .createdBy(faculty.getCreatedBy())

--- a/server/src/main/java/org/example/backend/mapper/LecturerMapper.java
+++ b/server/src/main/java/org/example/backend/mapper/LecturerMapper.java
@@ -2,8 +2,13 @@ package org.example.backend.mapper;
 
 import org.example.backend.domain.Lecturer;
 import org.example.backend.dto.request.LecturerRequest;
+import org.example.backend.dto.response.ClassSummaryResponse;
 import org.example.backend.dto.response.LecturerResponse;
 import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @Component
 public class LecturerMapper {
@@ -16,6 +21,36 @@ public class LecturerMapper {
                 .facultyId(lecturer.getFaculty().getId())
                 .facultyName(lecturer.getFaculty().getFacultyName())
                 .classes(lecturer.getClasses() != null ? lecturer.getClasses().stream().map(ClassMapper::mapFromDomainToClassSummaryResponse).toList() : null)
+                .createdAt(lecturer.getCreatedAt())
+                .updatedAt(lecturer.getUpdatedAt())
+                .createdBy(lecturer.getCreatedBy())
+                .updatedBy(lecturer.getUpdatedBy())
+                .build();
+    }
+
+    public static LecturerResponse mapFromDomainToResponseWithTranslation(
+            Lecturer lecturer,
+            Map<String, String> facultyTranslations,
+            Map<Integer, Map<String, String>> classTranslations) {
+
+        List<ClassSummaryResponse> classResponses = null;
+        if (lecturer.getClasses() != null && !lecturer.getClasses().isEmpty()) {
+            classResponses = lecturer.getClasses().stream()
+                    .map(aClass -> {
+                        Map<String, String> translations = classTranslations.getOrDefault(aClass.getId(), Collections.emptyMap());
+                        return ClassMapper.mapFromDomainToClassSummaryResponseWithTranslation(aClass, translations);
+                    })
+                    .toList();
+        }
+
+        return LecturerResponse.builder()
+                .id(lecturer.getId())
+                .fullName(lecturer.getFullName())
+                .email(lecturer.getEmail())
+                .phone(lecturer.getPhone())
+                .facultyId(lecturer.getFaculty().getId())
+                .facultyName(facultyTranslations.getOrDefault("facultyName", lecturer.getFaculty().getFacultyName()))
+                .classes(classResponses)
                 .createdAt(lecturer.getCreatedAt())
                 .updatedAt(lecturer.getUpdatedAt())
                 .createdBy(lecturer.getCreatedBy())

--- a/server/src/main/java/org/example/backend/mapper/ProgramMapper.java
+++ b/server/src/main/java/org/example/backend/mapper/ProgramMapper.java
@@ -3,7 +3,11 @@ package org.example.backend.mapper;
 import org.example.backend.domain.Program;
 import org.example.backend.dto.request.ProgramRequest;
 import org.example.backend.dto.response.ProgramResponse;
+import org.example.backend.dto.response.StudentResponse;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ProgramMapper {
@@ -18,6 +22,41 @@ public class ProgramMapper {
                 .id(program.getId())
                 .programName(program.getProgramName())
                 .students(program.getStudents() != null ? program.getStudents().stream().map(StudentMapper::mapToResponse).collect(Collectors.toList()) : null)
+                .createdAt(program.getCreatedAt())
+                .updatedAt(program.getUpdatedAt())
+                .createdBy(program.getCreatedBy())
+                .updatedBy(program.getUpdatedBy())
+                .build();
+    }
+
+    public static ProgramResponse mapToResponseWithTranslation(
+            Program program,
+            Map<String, String> programTranslations,
+            Map<Integer, Map<String, String>> studentTranslations) {
+
+        List<StudentResponse> studentResponses = null;
+        if (program.getStudents() != null) {
+            studentResponses = program.getStudents().stream()
+                    .map(student -> {
+                        Map<String, String> studentTrans = studentTranslations.getOrDefault(Integer.parseInt(student.getStudentId().replaceAll("[^\\d]", "")), Collections.emptyMap());
+
+                        return StudentMapper.mapToResponseWithTranslation(
+                                student,
+                                studentTrans,
+                                Collections.emptyMap(),
+                                Collections.emptyMap(),
+                                Collections.emptyMap(),
+                                Collections.emptyMap(),
+                                Collections.emptyMap()
+                        );
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        return ProgramResponse.builder()
+                .id(program.getId())
+                .programName(programTranslations.getOrDefault("programName", program.getProgramName()))
+                .students(studentResponses)
                 .createdAt(program.getCreatedAt())
                 .updatedAt(program.getUpdatedAt())
                 .createdBy(program.getCreatedBy())

--- a/server/src/main/java/org/example/backend/mapper/StudentMapper.java
+++ b/server/src/main/java/org/example/backend/mapper/StudentMapper.java
@@ -4,9 +4,14 @@ import org.example.backend.domain.Address;
 import org.example.backend.domain.Document;
 import org.example.backend.domain.Student;
 import org.example.backend.dto.request.StudentRequest;
+import org.example.backend.dto.response.AddressResponse;
+import org.example.backend.dto.response.DocumentResponse;
 import org.example.backend.dto.response.StudentResponse;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
@@ -64,6 +69,57 @@ public class StudentMapper {
                 .nationality(student.getNationality())
                 .addresses(student.getAddresses() != null ? student.getAddresses().stream().map(AddressMapper::mapToResponse).collect(Collectors.toList()) : null)
                 .documents(student.getDocuments() != null ? student.getDocuments().stream().map(DocumentMapper::mapToResponse).collect(Collectors.toList()) : null)
+                .createdAt(student.getCreatedAt())
+                .updatedAt(student.getUpdatedAt())
+                .createdBy(student.getCreatedBy())
+                .updatedBy(student.getUpdatedBy())
+                .build();
+    }
+
+    public static StudentResponse mapToResponseWithTranslation(
+            Student student,
+            Map<String, String> studentTranslations,
+            Map<String, String> facultyTranslations,
+            Map<String, String> programTranslations,
+            Map<String, String> statusTranslations,
+            Map<Integer, Map<String, String>> addressTranslations,
+            Map<Integer, Map<String, String>> documentTranslations) {
+
+        List<AddressResponse> addressResponses = null;
+        if (student.getAddresses() != null && !student.getAddresses().isEmpty()) {
+            addressResponses = student.getAddresses().stream()
+                    .map(address -> {
+                        Map<String, String> translations = addressTranslations.getOrDefault(address.getId(), Collections.emptyMap());
+                        return AddressMapper.mapToResponseWithTranslation(address, translations);
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        List<DocumentResponse> documentResponses = null;
+        if (student.getDocuments() != null && !student.getDocuments().isEmpty()) {
+            documentResponses = student.getDocuments().stream()
+                    .map(document -> {
+                        Map<String, String> translations = documentTranslations.getOrDefault(document.getId(), Collections.emptyMap());
+                        return DocumentMapper.mapToResponseWithTranslation(document, translations);
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        return StudentResponse.builder()
+                .studentId(student.getStudentId())
+                .fullName(student.getFullName())
+                .dob(student.getDob())
+                .gender(studentTranslations.getOrDefault("gender", student.getGender()))
+                .faculty(facultyTranslations.getOrDefault("facultyName", student.getFaculty().getFacultyName()))
+                .intake(student.getIntake())
+                .program(programTranslations.getOrDefault("programName", student.getProgram().getProgramName()))
+                .email(student.getEmail())
+                .phoneCountry(student.getPhoneCountry())
+                .phone(student.getPhone())
+                .studentStatus(statusTranslations.getOrDefault("studentStatusName", student.getStudentStatus().getStudentStatusName()))
+                .nationality(studentTranslations.getOrDefault("nationality", student.getNationality()))
+                .addresses(addressResponses)
+                .documents(documentResponses)
                 .createdAt(student.getCreatedAt())
                 .updatedAt(student.getUpdatedAt())
                 .createdBy(student.getCreatedBy())

--- a/server/src/main/java/org/example/backend/mapper/StudentStatusMapper.java
+++ b/server/src/main/java/org/example/backend/mapper/StudentStatusMapper.java
@@ -2,26 +2,66 @@ package org.example.backend.mapper;
 
 import org.example.backend.domain.StudentStatus;
 import org.example.backend.dto.request.StudentStatusRequest;
+import org.example.backend.dto.response.StudentResponse;
 import org.example.backend.dto.response.StudentStatusResponse;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class StudentStatusMapper {
-    public static StudentStatus toDomainFromRequestDTO(StudentStatusRequest request) {
+    public static StudentStatus mapToDomain(StudentStatusRequest request) {
         return StudentStatus.builder()
                 .studentStatusName(request.getStudentStatusName())
                 .build();
     }
 
-    public static StudentStatusResponse toResponseDTO(StudentStatus tinhTrangSinhVien) {
+    public static StudentStatusResponse mapToResponse(StudentStatus studentStatus) {
         return StudentStatusResponse.builder()
-                .id(tinhTrangSinhVien.getId())
-                .studentStatusName(tinhTrangSinhVien.getStudentStatusName())
-                .students(tinhTrangSinhVien.getStudents() != null ? tinhTrangSinhVien.getStudents().stream().map(StudentMapper::mapToResponse).collect(Collectors.toList()) : null)
-                .createdAt(tinhTrangSinhVien.getCreatedAt())
-                .updatedAt(tinhTrangSinhVien.getUpdatedAt())
-                .createdBy(tinhTrangSinhVien.getCreatedBy())
-                .updatedBy(tinhTrangSinhVien.getUpdatedBy())
+                .id(studentStatus.getId())
+                .studentStatusName(studentStatus.getStudentStatusName())
+                .students(studentStatus.getStudents() != null ? studentStatus.getStudents().stream().map(StudentMapper::mapToResponse).collect(Collectors.toList()) : null)
+                .createdAt(studentStatus.getCreatedAt())
+                .updatedAt(studentStatus.getUpdatedAt())
+                .createdBy(studentStatus.getCreatedBy())
+                .updatedBy(studentStatus.getUpdatedBy())
+                .build();
+    }
+
+    public static StudentStatusResponse mapToResponseWithTranslation(
+            StudentStatus studentStatus,
+            Map<String, String> statusTranslations,
+            Map<Integer, Map<String, String>> studentTranslations) {
+
+        List<StudentResponse> studentResponses = null;
+        if (studentStatus.getStudents() != null) {
+            studentResponses = studentStatus.getStudents().stream()
+                    .map(student -> {
+                        Map<String, String> studentTrans = studentTranslations.getOrDefault(Integer.parseInt(student.getStudentId().replaceAll("[^\\d]", "")), Collections.emptyMap());
+
+                        // Pass empty maps for other translation types since the full method requires them
+                        return StudentMapper.mapToResponseWithTranslation(
+                                student,
+                                studentTrans,
+                                Collections.emptyMap(), // facultyTranslations
+                                Collections.emptyMap(), // programTranslations
+                                Collections.emptyMap(), // statusTranslations
+                                Collections.emptyMap(), // addressTranslations
+                                Collections.emptyMap()  // documentTranslations
+                        );
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        return StudentStatusResponse.builder()
+                .id(studentStatus.getId())
+                .studentStatusName(statusTranslations.getOrDefault("studentStatusName", studentStatus.getStudentStatusName()))
+                .students(studentResponses)
+                .createdAt(studentStatus.getCreatedAt())
+                .updatedAt(studentStatus.getUpdatedAt())
+                .createdBy(studentStatus.getCreatedBy())
+                .updatedBy(studentStatus.getUpdatedBy())
                 .build();
     }
 }

--- a/server/src/main/java/org/example/backend/repository/ITranslationRepository.java
+++ b/server/src/main/java/org/example/backend/repository/ITranslationRepository.java
@@ -1,0 +1,14 @@
+package org.example.backend.repository;
+
+import org.example.backend.domain.Translation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ITranslationRepository extends JpaRepository<Translation, Integer> {
+    List<Translation> findByEntityTypeAndEntityIdAndLanguageCode(
+            String entityType, Integer entityId, String languageCode);
+
+    List<Translation> findByEntityTypeAndEntityIdInAndLanguageCode(
+            String entityType, List<Integer> entityIds, String languageCode);
+}

--- a/server/src/main/java/org/example/backend/service/ITranslationService.java
+++ b/server/src/main/java/org/example/backend/service/ITranslationService.java
@@ -1,0 +1,14 @@
+package org.example.backend.service;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ITranslationService {
+    Map<Integer, Map<String, String>> getTranslations(
+            String entityType, List<Integer> entityIds, String languageCode);
+
+    Map<String, String> getTranslation(String entityType, Integer entityId, String languageCode);
+
+    void saveTranslation(String entityType, Integer entityId,
+                                String fieldName, String languageCode, String value);
+}

--- a/server/src/main/java/org/example/backend/service/impl/LecturerServiceImpl.java
+++ b/server/src/main/java/org/example/backend/service/impl/LecturerServiceImpl.java
@@ -3,6 +3,8 @@ package org.example.backend.service.impl;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.backend.common.LanguageInterceptor;
+import org.example.backend.domain.Class;
 import org.example.backend.domain.Faculty;
 import org.example.backend.domain.Lecturer;
 import org.example.backend.dto.request.LecturerRequest;
@@ -11,9 +13,14 @@ import org.example.backend.mapper.LecturerMapper;
 import org.example.backend.repository.IFacultyRepository;
 import org.example.backend.repository.ILecturerRepository;
 import org.example.backend.service.ILecturerService;
+import org.example.backend.service.ITranslationService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @Slf4j
@@ -21,24 +28,75 @@ import org.springframework.stereotype.Service;
 public class LecturerServiceImpl implements ILecturerService {
     private final ILecturerRepository lecturerRepository;
     private final IFacultyRepository facultyRepository;
+    private final ITranslationService translationService;
 
     @Override
     public Page<LecturerResponse> getAllLecturers(Pageable pageable) {
         log.info("Getting all lecturers");
-
         Page<Lecturer> lecturerPage = lecturerRepository.findAll(pageable);
 
-        return lecturerPage.map(LecturerMapper::mapFromDomainToResponse);
+        String currentLanguage = LanguageInterceptor.CURRENT_LANGUAGE.get();
+        if ("vi".equals(currentLanguage)) {
+            return lecturerPage.map(LecturerMapper::mapFromDomainToResponse);
+        } else {
+            // Get translations for faculties
+            List<Integer> facultyIds = lecturerPage.getContent().stream()
+                    .map(lecturer -> lecturer.getFaculty().getId())
+                    .distinct()
+                    .toList();
+            Map<Integer, Map<String, String>> facultyTranslations = translationService
+                    .getTranslations("Faculty", facultyIds, currentLanguage);
+
+            // Get translations for classes
+            List<Integer> classIds = lecturerPage.getContent().stream()
+                    .filter(lecturer -> lecturer.getClasses() != null && !lecturer.getClasses().isEmpty())
+                    .flatMap(lecturer -> lecturer.getClasses().stream())
+                    .map(Class::getId)
+                    .distinct()
+                    .toList();
+
+            Map<Integer, Map<String, String>> classTranslations = classIds.isEmpty() ?
+                    Collections.emptyMap() :
+                    translationService.getTranslations("Class", classIds, currentLanguage);
+
+            return lecturerPage.map(lecturer -> LecturerMapper.mapFromDomainToResponseWithTranslation(
+                    lecturer,
+                    facultyTranslations.getOrDefault(lecturer.getFaculty().getId(), Collections.emptyMap()),
+                    classTranslations
+            ));
+        }
     }
 
     @Override
     public LecturerResponse getLecturerById(Integer lecturerId) {
         log.info("Getting lecturer by id: {}", lecturerId);
-
         Lecturer lecturer = lecturerRepository.findById(lecturerId)
                 .orElseThrow(() -> new RuntimeException("Lecturer not found"));
 
-        return LecturerMapper.mapFromDomainToResponse(lecturer);
+        String currentLanguage = LanguageInterceptor.CURRENT_LANGUAGE.get();
+        if ("vi".equals(currentLanguage)) {
+            return LecturerMapper.mapFromDomainToResponse(lecturer);
+        } else {
+            // Get translation for faculty
+            Map<String, String> facultyTranslations = translationService.getTranslation(
+                    "Faculty", lecturer.getFaculty().getId(), currentLanguage);
+
+            // Get translations for classes if present
+            Map<Integer, Map<String, String>> classTranslations = Collections.emptyMap();
+            if (lecturer.getClasses() != null && !lecturer.getClasses().isEmpty()) {
+                List<Integer> classIds = lecturer.getClasses().stream()
+                        .map(Class::getId)
+                        .toList();
+                classTranslations = translationService
+                        .getTranslations("Class", classIds, currentLanguage);
+            }
+
+            return LecturerMapper.mapFromDomainToResponseWithTranslation(
+                    lecturer,
+                    facultyTranslations,
+                    classTranslations
+            );
+        }
     }
 
     @Override

--- a/server/src/main/java/org/example/backend/service/impl/StudentServiceImpl.java
+++ b/server/src/main/java/org/example/backend/service/impl/StudentServiceImpl.java
@@ -3,6 +3,7 @@ package org.example.backend.service.impl;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.backend.common.LanguageInterceptor;
 import org.example.backend.common.RegistrationStatus;
 import org.example.backend.domain.Address;
 import org.example.backend.domain.ClassRegistration;
@@ -24,6 +25,7 @@ import org.example.backend.repository.IProgramRepository;
 import org.example.backend.repository.IStudentRepository;
 import org.example.backend.repository.IStudentStatusRepository;
 import org.example.backend.service.IStudentService;
+import org.example.backend.service.ITranslationService;
 import org.example.backend.service.export.TranscriptPdfExportService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,6 +34,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -46,6 +49,7 @@ public class StudentServiceImpl implements IStudentService {
     private final IStudentStatusRepository studentStatusRepository;
     private final IClassRegistrationRepository classRegistrationRepository;
     private final TranscriptPdfExportService transcriptPdfExportService;
+    private final ITranslationService translationService;
 
     @Override
     @Transactional
@@ -81,16 +85,139 @@ public class StudentServiceImpl implements IStudentService {
 
     @Override
     public StudentResponse getStudent(String studentId) {
-        Student student = studentRepository.findByStudentId(studentId).orElseThrow(() -> new RuntimeException("Student not found"));
+        Student student = studentRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new RuntimeException("Student not found"));
 
         log.info("Student {} has been retrieved", student.getStudentId());
 
-        return StudentMapper.mapToResponse(student);
+        String currentLanguage = LanguageInterceptor.CURRENT_LANGUAGE.get();
+        if ("vi".equals(currentLanguage)) {
+            return StudentMapper.mapToResponse(student);
+        } else {
+            // Get translation for student
+            Map<String, String> studentTranslations = translationService.getTranslation(
+                    "Student", Integer.parseInt(student.getStudentId().replaceAll("[^\\d]", "")), currentLanguage);
+
+            // Get translation for faculty
+            Map<String, String> facultyTranslations = translationService.getTranslation(
+                    "Faculty", student.getFaculty().getId(), currentLanguage);
+
+            // Get translation for program
+            Map<String, String> programTranslations = translationService.getTranslation(
+                    "Program", student.getProgram().getId(), currentLanguage);
+
+            // Get translation for student status
+            Map<String, String> studentStatusTranslations = translationService.getTranslation(
+                    "StudentStatus", student.getStudentStatus().getId(), currentLanguage);
+
+            // Get translations for addresses if present
+            Map<Integer, Map<String, String>> addressTranslations = Collections.emptyMap();
+            if (student.getAddresses() != null && !student.getAddresses().isEmpty()) {
+                List<Integer> addressIds = student.getAddresses().stream()
+                        .map(Address::getId)
+                        .toList();
+                addressTranslations = translationService
+                        .getTranslations("Address", addressIds, currentLanguage);
+            }
+
+            // Get translations for documents if present
+            Map<Integer, Map<String, String>> documentTranslations = Collections.emptyMap();
+            if (student.getDocuments() != null && !student.getDocuments().isEmpty()) {
+                List<Integer> documentIds = student.getDocuments().stream()
+                        .map(Document::getId)
+                        .toList();
+                documentTranslations = translationService
+                        .getTranslations("Document", documentIds, currentLanguage);
+            }
+
+            return StudentMapper.mapToResponseWithTranslation(
+                    student,
+                    studentTranslations,
+                    facultyTranslations,
+                    programTranslations,
+                    studentStatusTranslations,
+                    addressTranslations,
+                    documentTranslations
+            );
+        }
     }
 
     @Override
     public Page<StudentResponse> getAllStudents(Pageable pageable) {
-        return studentRepository.findAll(pageable).map(StudentMapper::mapToResponse);
+        Page<Student> studentPage = studentRepository.findAll(pageable);
+
+        String currentLanguage = LanguageInterceptor.CURRENT_LANGUAGE.get();
+        if ("vi".equals(currentLanguage)) {
+            return studentPage.map(StudentMapper::mapToResponse);
+        } else {
+            // Get translations for students
+            List<Integer> studentIds = studentPage.getContent().stream()
+                    .map(Student::getStudentId)
+                    .map(id -> Integer.parseInt(id.replaceAll("[^\\d]", "")))
+                    .toList();
+            Map<Integer, Map<String, String>> studentTranslations = translationService
+                    .getTranslations("Student", studentIds, currentLanguage);
+
+            // Get translations for faculties
+            List<Integer> facultyIds = studentPage.getContent().stream()
+                    .map(student -> student.getFaculty().getId())
+                    .distinct()
+                    .toList();
+            Map<Integer, Map<String, String>> facultyTranslations = translationService
+                    .getTranslations("Faculty", facultyIds, currentLanguage);
+
+            // Get translations for programs
+            List<Integer> programIds = studentPage.getContent().stream()
+                    .map(student -> student.getProgram().getId())
+                    .distinct()
+                    .toList();
+            Map<Integer, Map<String, String>> programTranslations = translationService
+                    .getTranslations("Program", programIds, currentLanguage);
+
+            // Get translations for student statuses
+            List<Integer> statusIds = studentPage.getContent().stream()
+                    .map(student -> student.getStudentStatus().getId())
+                    .distinct()
+                    .toList();
+            Map<Integer, Map<String, String>> statusTranslations = translationService
+                    .getTranslations("StudentStatus", statusIds, currentLanguage);
+
+            // Get all address IDs
+            List<Integer> allAddressIds = studentPage.getContent().stream()
+                    .filter(student -> student.getAddresses() != null && !student.getAddresses().isEmpty())
+                    .flatMap(student -> student.getAddresses().stream())
+                    .map(Address::getId)
+                    .distinct()
+                    .toList();
+
+            // Get translations for addresses
+            Map<Integer, Map<String, String>> addressTranslations = allAddressIds.isEmpty() ?
+                    Collections.emptyMap() :
+                    translationService.getTranslations("Address", allAddressIds, currentLanguage);
+
+            // Get all document IDs
+            List<Integer> allDocumentIds = studentPage.getContent().stream()
+                    .filter(student -> student.getDocuments() != null && !student.getDocuments().isEmpty())
+                    .flatMap(student -> student.getDocuments().stream())
+                    .map(Document::getId)
+                    .distinct()
+                    .toList();
+
+            // Get translations for documents
+            Map<Integer, Map<String, String>> documentTranslations = allDocumentIds.isEmpty() ?
+                    Collections.emptyMap() :
+                    translationService.getTranslations("Document", allDocumentIds, currentLanguage);
+
+            return studentPage.map(student -> StudentMapper.mapToResponseWithTranslation(
+                    student,
+                    studentTranslations.getOrDefault(Integer.parseInt(student.getStudentId().replaceAll("[^\\d]", "")), Collections.emptyMap()),
+                    facultyTranslations.getOrDefault(student.getFaculty().getId(), Collections.emptyMap()),
+                    programTranslations.getOrDefault(student.getProgram().getId(), Collections.emptyMap()),
+                    statusTranslations.getOrDefault(student.getStudentStatus().getId(), Collections.emptyMap()),
+                    addressTranslations,
+                    documentTranslations
+            ));
+        }
     }
 
     @Override
@@ -190,7 +317,81 @@ public class StudentServiceImpl implements IStudentService {
 
     @Override
     public Page<StudentResponse> searchStudent(String keyword, Pageable pageable) {
-        return studentRepository.searchByKeyword(keyword, pageable).map(StudentMapper::mapToResponse);
+        Page<Student> studentPage = studentRepository.searchByKeyword(keyword, pageable);
+
+        String currentLanguage = LanguageInterceptor.CURRENT_LANGUAGE.get();
+        if ("vi".equals(currentLanguage)) {
+            return studentPage.map(StudentMapper::mapToResponse);
+        } else {
+            // Get translations for students
+            List<Integer> studentIds = studentPage.getContent().stream()
+                    .map(Student::getStudentId)
+                    .map(id -> Integer.parseInt(id.replaceAll("[^\\d]", "")))
+                    .toList();
+            Map<Integer, Map<String, String>> studentTranslations = translationService
+                    .getTranslations("Student", studentIds, currentLanguage);
+
+            // Get translations for faculties
+            List<Integer> facultyIds = studentPage.getContent().stream()
+                    .map(student -> student.getFaculty().getId())
+                    .distinct()
+                    .toList();
+            Map<Integer, Map<String, String>> facultyTranslations = translationService
+                    .getTranslations("Faculty", facultyIds, currentLanguage);
+
+            // Get translations for programs
+            List<Integer> programIds = studentPage.getContent().stream()
+                    .map(student -> student.getProgram().getId())
+                    .distinct()
+                    .toList();
+            Map<Integer, Map<String, String>> programTranslations = translationService
+                    .getTranslations("Program", programIds, currentLanguage);
+
+            // Get translations for student statuses
+            List<Integer> statusIds = studentPage.getContent().stream()
+                    .map(student -> student.getStudentStatus().getId())
+                    .distinct()
+                    .toList();
+            Map<Integer, Map<String, String>> statusTranslations = translationService
+                    .getTranslations("StudentStatus", statusIds, currentLanguage);
+
+            // Get all address IDs
+            List<Integer> allAddressIds = studentPage.getContent().stream()
+                    .filter(student -> student.getAddresses() != null && !student.getAddresses().isEmpty())
+                    .flatMap(student -> student.getAddresses().stream())
+                    .map(Address::getId)
+                    .distinct()
+                    .toList();
+
+            // Get translations for addresses
+            Map<Integer, Map<String, String>> addressTranslations = allAddressIds.isEmpty() ?
+                    Collections.emptyMap() :
+                    translationService.getTranslations("Address", allAddressIds, currentLanguage);
+
+            // Get all document IDs
+            List<Integer> allDocumentIds = studentPage.getContent().stream()
+                    .filter(student -> student.getDocuments() != null && !student.getDocuments().isEmpty())
+                    .flatMap(student -> student.getDocuments().stream())
+                    .map(Document::getId)
+                    .distinct()
+                    .toList();
+
+            // Get translations for documents
+            Map<Integer, Map<String, String>> documentTranslations = allDocumentIds.isEmpty() ?
+                    Collections.emptyMap() :
+                    translationService.getTranslations("Document", allDocumentIds, currentLanguage);
+
+            return studentPage.map(student -> StudentMapper.mapToResponseWithTranslation(
+                    student,
+                    studentTranslations.getOrDefault(Integer.parseInt(student.getStudentId().replaceAll("[^\\d]", "")), Collections.emptyMap()),
+                    facultyTranslations.getOrDefault(student.getFaculty().getId(), Collections.emptyMap()),
+                    programTranslations.getOrDefault(student.getProgram().getId(), Collections.emptyMap()),
+                    statusTranslations.getOrDefault(student.getStudentStatus().getId(), Collections.emptyMap()),
+                    addressTranslations,
+                    documentTranslations
+            ));
+
+        }
     }
 
     @Override

--- a/server/src/main/java/org/example/backend/service/impl/StudentStatusServiceImpl.java
+++ b/server/src/main/java/org/example/backend/service/impl/StudentStatusServiceImpl.java
@@ -2,15 +2,20 @@ package org.example.backend.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.backend.common.LanguageInterceptor;
+import org.example.backend.domain.Student;
 import org.example.backend.domain.StudentStatus;
 import org.example.backend.dto.request.StudentStatusRequest;
 import org.example.backend.dto.response.StudentStatusResponse;
 import org.example.backend.mapper.StudentStatusMapper;
 import org.example.backend.repository.IStudentStatusRepository;
 import org.example.backend.service.IStudentStatusService;
+import org.example.backend.service.ITranslationService;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -18,6 +23,7 @@ import java.util.stream.Collectors;
 @Slf4j
 public class StudentStatusServiceImpl implements IStudentStatusService {
     private final IStudentStatusRepository studentStatusRepository;
+    private final ITranslationService translationService;
 
     @Override
     public StudentStatusResponse addStudentStatus(StudentStatusRequest request) {
@@ -26,23 +32,57 @@ public class StudentStatusServiceImpl implements IStudentStatusService {
             throw new RuntimeException("Student status already exists");
         }
 
-        StudentStatus studentStatus = StudentStatusMapper.toDomainFromRequestDTO(request);
+        StudentStatus studentStatus = StudentStatusMapper.mapToDomain(request);
         studentStatus = studentStatusRepository.save(studentStatus);
 
         log.info("Student status saved to database successfully");
 
-        return StudentStatusMapper.toResponseDTO(studentStatus);
+        return StudentStatusMapper.mapToResponse(studentStatus);
     }
 
     @Override
     public List<StudentStatusResponse> getAllStudentStatuses() {
         List<StudentStatus> studentStatuses = studentStatusRepository.findAll();
-
         log.info("Retrieved all student statuses from database");
 
-        return studentStatuses.stream()
-                .map(StudentStatusMapper::toResponseDTO)
-                .collect(Collectors.toList());
+        String currentLanguage = LanguageInterceptor.CURRENT_LANGUAGE.get();
+        if ("vi".equals(currentLanguage)) {
+            return studentStatuses.stream()
+                    .map(StudentStatusMapper::mapToResponse)
+                    .collect(Collectors.toList());
+        } else {
+            // Get translations for student statuses
+            List<Integer> statusIds = studentStatuses.stream()
+                    .map(StudentStatus::getId)
+                    .toList();
+            Map<Integer, Map<String, String>> statusTranslations = translationService
+                    .getTranslations("StudentStatus", statusIds, currentLanguage);
+
+            // If statuses have students, get translations for students and related entities
+            List<Integer> studentIds = studentStatuses.stream()
+                    .filter(status -> status.getStudents() != null && !status.getStudents().isEmpty())
+                    .flatMap(status -> status.getStudents().stream())
+                    .map(Student::getStudentId)
+                    .map(studentId -> Integer.parseInt(studentId.replaceAll("[^\\d]", "")))
+                    .distinct()
+                    .toList();
+
+            Map<Integer, Map<String, String>> studentTranslations = Collections.emptyMap();
+            if (!studentIds.isEmpty()) {
+                studentTranslations = translationService
+                        .getTranslations("Student", studentIds, currentLanguage);
+            }
+
+            final Map<Integer, Map<String, String>> finalStudentTranslations = studentTranslations;
+
+            return studentStatuses.stream()
+                    .map(status -> StudentStatusMapper.mapToResponseWithTranslation(
+                            status,
+                            statusTranslations.getOrDefault(status.getId(), Collections.emptyMap()),
+                            finalStudentTranslations
+                    ))
+                    .collect(Collectors.toList());
+        }
     }
 
     @Override
@@ -55,7 +95,31 @@ public class StudentStatusServiceImpl implements IStudentStatusService {
 
         log.info("Retrieved student status from database");
 
-        return StudentStatusMapper.toResponseDTO(studentStatus);
+        String currentLanguage = LanguageInterceptor.CURRENT_LANGUAGE.get();
+        if ("vi".equals(currentLanguage)) {
+            return StudentStatusMapper.mapToResponse(studentStatus);
+        } else {
+            // Get translation for student status
+            Map<String, String> statusTranslations = translationService.getTranslation(
+                    "StudentStatus", studentStatus.getId(), currentLanguage);
+
+            // Get translations for students if present
+            Map<Integer, Map<String, String>> studentTranslations = Collections.emptyMap();
+            if (studentStatus.getStudents() != null && !studentStatus.getStudents().isEmpty()) {
+                List<Integer> studentIds = studentStatus.getStudents().stream()
+                        .map(Student::getStudentId)
+                        .map(studentId -> Integer.parseInt(studentId.replaceAll("[^\\d]", "")))
+                        .toList();
+                studentTranslations = translationService
+                        .getTranslations("Student", studentIds, currentLanguage);
+            }
+
+            return StudentStatusMapper.mapToResponseWithTranslation(
+                    studentStatus,
+                    statusTranslations,
+                    studentTranslations
+            );
+        }
     }
 
     @Override
@@ -71,7 +135,7 @@ public class StudentStatusServiceImpl implements IStudentStatusService {
 
         log.info("Student status updated successfully");
 
-        return StudentStatusMapper.toResponseDTO(studentStatus);
+        return StudentStatusMapper.mapToResponse(studentStatus);
     }
 
     @Override

--- a/server/src/main/java/org/example/backend/service/impl/TranslationService.java
+++ b/server/src/main/java/org/example/backend/service/impl/TranslationService.java
@@ -1,0 +1,50 @@
+package org.example.backend.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.domain.Translation;
+import org.example.backend.repository.ITranslationRepository;
+import org.example.backend.service.ITranslationService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TranslationService implements ITranslationService {
+    private final ITranslationRepository translationRepository;
+
+    @Override
+    public Map<Integer, Map<String, String>> getTranslations(String entityType, List<Integer> entityIds, String languageCode) {
+        List<Translation> translations = translationRepository
+                .findByEntityTypeAndEntityIdInAndLanguageCode(entityType, entityIds, languageCode);
+
+        return translations.stream()
+                .collect(Collectors.groupingBy(Translation::getEntityId,
+                        Collectors.toMap(Translation::getFieldName, Translation::getTranslatedValue)));
+    }
+
+    @Override
+    public Map<String, String> getTranslation(String entityType, Integer entityId, String languageCode) {
+        List<Translation> translations = translationRepository
+                .findByEntityTypeAndEntityIdAndLanguageCode(entityType, entityId, languageCode);
+
+        return translations.stream()
+                .collect(Collectors.toMap(Translation::getFieldName, Translation::getTranslatedValue));
+    }
+
+    @Override
+    public void saveTranslation(String entityType, Integer entityId, String fieldName, String languageCode, String value) {
+        Translation translation = new Translation();
+        translation.setEntityType(entityType);
+        translation.setEntityId(entityId);
+        translation.setFieldName(fieldName);
+        translation.setLanguageCode(languageCode);
+        translation.setTranslatedValue(value);
+
+        translationRepository.save(translation);
+    }
+}

--- a/server/src/main/resources/db/1_create_table.sql
+++ b/server/src/main/resources/db/1_create_table.sql
@@ -224,3 +224,19 @@ CREATE TABLE email_domains (
     created_by VARCHAR(100) DEFAULT 'admin',
     updated_by VARCHAR(100) DEFAULT 'admin'
 );
+
+CREATE TABLE translations (
+    id SERIAL PRIMARY KEY,
+    entity_type VARCHAR(50) NOT NULL,
+    entity_id SERIAL NOT NULL,
+    field_name VARCHAR(50) NOT NULL,
+    language_code VARCHAR(10) NOT NULL,
+    translated_value TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted BOOLEAN DEFAULT FALSE,
+    created_by VARCHAR(100) DEFAULT 'admin',
+    updated_by VARCHAR(100) DEFAULT 'admin'
+);
+
+CREATE INDEX idx_translation_lookup ON translations (entity_type, entity_id, field_name, language_code);

--- a/server/src/main/resources/db/2_insert_data.sql
+++ b/server/src/main/resources/db/2_insert_data.sql
@@ -80,16 +80,16 @@ INSERT INTO student_status_rules (current_status_id, allowed_transition_id) VALU
 
 INSERT INTO courses (course_code, course_name, credits, faculty_id, description, prerequisite_course_id, is_active, created_by, updated_by)
 VALUES
-    ('CS101', 'Introduction to Programming', 3, 1, 'Basic programming concepts', NULL, TRUE, 'admin', 'admin'),
-    ('CS102', 'Data Structures', 3, 1, 'Study of data structures', 1, TRUE, 'admin', 'admin'),
-    ('CS103', 'Algorithms', 3, 1, 'Fundamentals of algorithms', 2, TRUE, 'admin', 'admin'),
-    ('CS104', 'Database Systems', 3, 2, 'Database design and SQL', NULL, TRUE, 'admin', 'admin'),
-    ('CS105', 'Computer Networks', 3, 3, 'Network protocols and security', NULL, TRUE, 'admin', 'admin'),
-    ('CS106', 'Operating Systems', 3, 1, 'Processes, threads, and memory management', NULL, TRUE, 'admin', 'admin'),
-    ('CS107', 'Software Engineering', 3, 2, 'Software development lifecycle', NULL, TRUE, 'admin', 'admin'),
-    ('CS108', 'Artificial Intelligence', 3, 3, 'Machine learning and AI concepts', 3, TRUE, 'admin', 'admin'),
-    ('CS109', 'Cyber Security', 3, 3, 'Cyber threats and security measures', NULL, TRUE, 'admin', 'admin'),
-    ('CS110', 'Cloud Computing', 3, 1, 'Introduction to cloud services', 4, TRUE, 'admin', 'admin');
+    ('CS101', 'Nhập môn Lập trình', 3, 1, 'Các khái niệm lập trình cơ bản', NULL, TRUE, 'admin', 'admin'),
+    ('CS102', 'Cấu trúc Dữ liệu', 3, 1, 'Nghiên cứu về cấu trúc dữ liệu', 1, TRUE, 'admin', 'admin'),
+    ('CS103', 'Thuật toán', 3, 1, 'Kiến thức nền tảng về thuật toán', 2, TRUE, 'admin', 'admin'),
+    ('CS104', 'Hệ quản trị Cơ sở dữ liệu', 3, 2, 'Thiết kế cơ sở dữ liệu và SQL', NULL, TRUE, 'admin', 'admin'),
+    ('CS105', 'Mạng Máy tính', 3, 3, 'Giao thức mạng và an ninh mạng', NULL, TRUE, 'admin', 'admin'),
+    ('CS106', 'Hệ điều hành', 3, 1, 'Tiến trình, luồng và quản lý bộ nhớ', NULL, TRUE, 'admin', 'admin'),
+    ('CS107', 'Kỹ thuật Phần mềm', 3, 2, 'Vòng đời phát triển phần mềm', NULL, TRUE, 'admin', 'admin'),
+    ('CS108', 'Trí tuệ Nhân tạo', 3, 3, 'Học máy và các khái niệm AI', 3, TRUE, 'admin', 'admin'),
+    ('CS109', 'An ninh Mạng', 3, 3, 'Các mối đe dọa và biện pháp bảo mật', NULL, TRUE, 'admin', 'admin'),
+    ('CS110', 'Điện toán Đám mây', 3, 1, 'Giới thiệu về các dịch vụ đám mây', 4, TRUE, 'admin', 'admin');
 
 INSERT INTO semesters (academic_year, semester, start_date, end_date, last_cancel_date)
 VALUES
@@ -110,30 +110,29 @@ VALUES
 
 INSERT INTO lecturers (full_name, email, phone, faculty_id)
 VALUES
-    ('Dr. John Doe', 'johndoe@university.edu', '1234567890', 1),
-    ('Dr. Jane Smith', 'janesmith@university.edu', '2345678901', 1),
-    ('Prof. Alice Brown', 'alicebrown@university.edu', '3456789012', 2),
-    ('Dr. Bob Johnson', 'bobjohnson@university.edu', '4567890123', 2),
-    ('Dr. Carol White', 'carolwhite@university.edu', '5678901234', 3),
-    ('Dr. David Green', 'davidgreen@university.edu', '6789012345', 3),
-    ('Prof. Eva Black', 'evablack@university.edu', '7890123456', 1),
-    ('Dr. Frank Wilson', 'frankwilson@university.edu', '8901234567', 2),
-    ('Dr. Grace Adams', 'graceadams@university.edu', '9012345678', 3),
-    ('Dr. Henry Clark', 'henryclark@university.edu', '0123456789', 1);
-
+    ('TS. Nguyễn Văn A', 'nguyenvana@university.edu', '0912345678', 1),
+    ('TS. Trần Thị B', 'tranthib@university.edu', '0923456789', 1),
+    ('GS. Lê Thị C', 'lethic@university.edu', '0934567890', 2),
+    ('TS. Phạm Văn D', 'phamvand@university.edu', '0945678901', 2),
+    ('TS. Đặng Thị E', 'dangthie@university.edu', '0956789012', 3),
+    ('TS. Hồ Văn F', 'hovanf@university.edu', '0967890123', 3),
+    ('GS. Vũ Thị G', 'vuthig@university.edu', '0978901234', 1),
+    ('TS. Bùi Văn H', 'buivanh@university.edu', '0989012345', 2),
+    ('TS. Nguyễn Thị I', 'nguyenthii@university.edu', '0990123456', 3),
+    ('TS. Lê Văn K', 'levank@university.edu', '0901234567', 1);
 
 INSERT INTO classes (class_code, course_id, semester_id, lecturer_id, max_students, schedule, room)
 VALUES
-    ('CS101-01', 1, 1, 1, 50, 'Mon-Wed 10:00-12:00', 'Room A101'),
-    ('CS102-01', 2, 1, 2, 40, 'Tue-Thu 14:00-16:00', 'Room B201'),
-    ('CS103-01', 3, 2, 3, 45, 'Mon-Wed 08:00-10:00', 'Room C301'),
-    ('CS104-01', 4, 2, 4, 35, 'Fri 09:00-12:00', 'Room D401'),
-    ('CS105-01', 5, 3, 5, 60, 'Tue-Thu 10:00-12:00', 'Room E501'),
-    ('CS106-01', 6, 3, 6, 30, 'Wed 14:00-17:00', 'Room F601'),
-    ('CS107-01', 7, 1, 7, 50, 'Thu 09:00-12:00', 'Room G701'),
-    ('CS108-01', 8, 2, 8, 40, 'Mon 14:00-17:00', 'Room H801'),
-    ('CS109-01', 9, 3, 9, 55, 'Fri 08:00-11:00', 'Room I901'),
-    ('CS110-01', 10, 1, 10, 50, 'Wed 09:00-12:00', 'Room J1001');
+    ('CS101-01', 1, 1, 1, 50, 'Thứ Hai - Thứ Tư 10:00-12:00', 'A101'),
+    ('CS102-01', 2, 1, 2, 40, 'Thứ Ba - Thứ Năm 14:00-16:00', 'B201'),
+    ('CS103-01', 3, 2, 3, 45, 'Thứ Hai - Thứ Tư 08:00-10:00', 'C301'),
+    ('CS104-01', 4, 2, 4, 35, 'Thứ Sáu 09:00-12:00', 'D401'),
+    ('CS105-01', 5, 3, 5, 60, 'Thứ Ba - Thứ Năm 10:00-12:00', 'E501'),
+    ('CS106-01', 6, 3, 6, 30, 'Thứ Tư 14:00-17:00', 'F601'),
+    ('CS107-01', 7, 1, 7, 50, 'Thứ Năm 09:00-12:00', 'G701'),
+    ('CS108-01', 8, 2, 8, 40, 'Thứ Hai 14:00-17:00', 'H801'),
+    ('CS109-01', 9, 3, 9, 55, 'Thứ Sáu 08:00-11:00', 'I901'),
+    ('CS110-01', 10, 1, 10, 50, 'Thứ Tư 09:00-12:00', 'J1001');
 
 
 INSERT INTO class_registrations (student_id, class_id, status, grade)

--- a/server/src/main/resources/db/3_insert_translations.sql
+++ b/server/src/main/resources/db/3_insert_translations.sql
@@ -1,0 +1,237 @@
+-- Dịch tên các khoa (faculties)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Faculty', 1, 'facultyName', 'en', 'Faculty of Law'),
+    ('Faculty', 2, 'facultyName', 'en', 'Faculty of Business English'),
+    ('Faculty', 3, 'facultyName', 'en', 'Faculty of Japanese'),
+    ('Faculty', 4, 'facultyName', 'en', 'Faculty of French');
+
+-- Dịch trạng thái sinh viên (student_statuses)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('StudentStatus', 1, 'studentStatusName', 'en', 'Enrolled'),
+    ('StudentStatus', 2, 'studentStatusName', 'en', 'Graduated'),
+    ('StudentStatus', 3, 'studentStatusName', 'en', 'Withdrawn'),
+    ('StudentStatus', 4, 'studentStatusName', 'en', 'Leave of Absence');
+
+-- Dịch tên chương trình học (programs)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Program', 1, 'programName', 'en', 'Full-time'),
+    ('Program', 2, 'programName', 'en', 'Articulation Program'),
+    ('Program', 3, 'programName', 'en', 'Work-Study Program');
+
+-- Dịch tên các môn học (courses)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Course', 1, 'courseName', 'en', 'Introduction to Programming'),
+    ('Course', 1, 'description', 'en', 'Basic programming concepts'),
+    ('Course', 2, 'courseName', 'en', 'Data Structures'),
+    ('Course', 2, 'description', 'en', 'Study of data structures'),
+    ('Course', 3, 'courseName', 'en', 'Algorithms'),
+    ('Course', 3, 'description', 'en', 'Fundamental knowledge of algorithms'),
+    ('Course', 4, 'courseName', 'en', 'Database Management Systems'),
+    ('Course', 4, 'description', 'en', 'Database design and SQL'),
+    ('Course', 5, 'courseName', 'en', 'Computer Networks'),
+    ('Course', 5, 'description', 'en', 'Network protocols and security'),
+    ('Course', 6, 'courseName', 'en', 'Operating Systems'),
+    ('Course', 6, 'description', 'en', 'Processes, threads and memory management'),
+    ('Course', 7, 'courseName', 'en', 'Software Engineering'),
+    ('Course', 7, 'description', 'en', 'Software development lifecycle'),
+    ('Course', 8, 'courseName', 'en', 'Artificial Intelligence'),
+    ('Course', 8, 'description', 'en', 'Machine learning and AI concepts'),
+    ('Course', 9, 'courseName', 'en', 'Network Security'),
+    ('Course', 9, 'description', 'en', 'Security threats and measures'),
+    ('Course', 10, 'courseName', 'en', 'Cloud Computing'),
+    ('Course', 10, 'description', 'en', 'Introduction to cloud services');
+
+-- Dịch lịch học của các lớp (classes.schedule)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Class', 1, 'schedule', 'en', 'Mon-Wed 10:00-12:00'),
+    ('Class', 2, 'schedule', 'en', 'Tue-Thu 14:00-16:00'),
+    ('Class', 3, 'schedule', 'en', 'Mon-Wed 08:00-10:00'),
+    ('Class', 4, 'schedule', 'en', 'Fri 09:00-12:00'),
+    ('Class', 5, 'schedule', 'en', 'Tue-Thu 10:00-12:00'),
+    ('Class', 6, 'schedule', 'en', 'Wed 14:00-17:00'),
+    ('Class', 7, 'schedule', 'en', 'Thu 09:00-12:00'),
+    ('Class', 8, 'schedule', 'en', 'Mon 14:00-17:00'),
+    ('Class', 9, 'schedule', 'en', 'Fri 08:00-11:00'),
+    ('Class', 10, 'schedule', 'en', 'Wed 09:00-12:00');
+
+-- Dịch lý do trong lịch sử đăng ký (class_registration_history.reason)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('ClassRegistrationHistory', 1, 'reason', 'en', 'Course registration'),
+    ('ClassRegistrationHistory', 2, 'reason', 'en', 'Course registration'),
+    ('ClassRegistrationHistory', 3, 'reason', 'en', 'Course registration'),
+    ('ClassRegistrationHistory', 4, 'reason', 'en', 'Course registration cancellation'),
+    ('ClassRegistrationHistory', 5, 'reason', 'en', 'Course registration cancellation'),
+    ('ClassRegistrationHistory', 6, 'reason', 'en', 'Course registration cancellation'),
+    ('ClassRegistrationHistory', 7, 'reason', 'en', 'Course completion'),
+    ('ClassRegistrationHistory', 8, 'reason', 'en', 'Course completion'),
+    ('ClassRegistrationHistory', 9, 'reason', 'en', 'Course completion'),
+    ('ClassRegistrationHistory', 10, 'reason', 'en', 'Course completion');
+
+-- Dịch loại địa chỉ (addresses.address_type)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Address', 1, 'addressType', 'en', 'Permanent Address'),
+    ('Address', 2, 'addressType', 'en', 'Temporary Address'),
+    ('Address', 3, 'addressType', 'en', 'Permanent Address'),
+    ('Address', 4, 'addressType', 'en', 'Permanent Address'),
+    ('Address', 5, 'addressType', 'en', 'Temporary Address'),
+    ('Address', 6, 'addressType', 'en', 'Permanent Address'),
+    ('Address', 7, 'addressType', 'en', 'Temporary Address'),
+    ('Address', 8, 'addressType', 'en', 'Permanent Address'),
+    ('Address', 9, 'addressType', 'en', 'Temporary Address'),
+    ('Address', 10, 'addressType', 'en', 'Permanent Address'),
+    ('Address', 11, 'addressType', 'en', 'Temporary Address'),
+    ('Address', 12, 'addressType', 'en', 'Permanent Address'),
+    ('Address', 13, 'addressType', 'en', 'Temporary Address'),
+    ('Address', 14, 'addressType', 'en', 'Permanent Address'),
+    ('Address', 15, 'addressType', 'en', 'Temporary Address');
+
+-- Dịch loại giấy tờ (documents.document_type)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Document', 1, 'documentType', 'en', 'Citizen ID Card'),
+    ('Document', 2, 'documentType', 'en', 'Passport');
+
+-- Dịch nơi cấp giấy tờ (documents.issued_by)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Document', 1, 'issuedBy', 'en', 'Ho Chi Minh City'),
+    ('Document', 2, 'issuedBy', 'en', 'Hanoi');
+
+-- Dịch ghi chú giấy tờ (documents.note)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Document', 2, 'note', 'en', 'Used for studying abroad');
+
+-- Dịch quốc tịch sinh viên (students.nationality)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Student', 1, 'nationality', 'en', 'Vietnam'),
+    ('Student', 2, 'nationality', 'en', 'Vietnam'),
+    ('Student', 3, 'nationality', 'en', 'Vietnam'),
+    ('Student', 4, 'nationality', 'en', 'Vietnam'),
+    ('Student', 5, 'nationality', 'en', 'Vietnam'),
+    ('Student', 6, 'nationality', 'en', 'United States'),
+    ('Student', 7, 'nationality', 'en', 'United Kingdom'),
+    ('Student', 8, 'nationality', 'en', 'Vietnam'),
+    ('Student', 9, 'nationality', 'en', 'China'),
+    ('Student', 10, 'nationality', 'en', 'Vietnam'),
+    ('Student', 11, 'nationality', 'en', 'France'),
+    ('Student', 12, 'nationality', 'en', 'Vietnam'),
+    ('Student', 13, 'nationality', 'en', 'Japan'),
+    ('Student', 14, 'nationality', 'en', 'South Korea'),
+    ('Student', 15, 'nationality', 'en', 'Vietnam'),
+    ('Student', 16, 'nationality', 'en', 'Italy'),
+    ('Student', 17, 'nationality', 'en', 'Australia'),
+    ('Student', 18, 'nationality', 'en', 'Spain'),
+    ('Student', 19, 'nationality', 'en', 'Mexico'),
+    ('Student', 20, 'nationality', 'en', 'India');
+
+-- Dịch giới tính sinh viên (students.gender)
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Student', 1, 'gender', 'en', 'Male'),
+    ('Student', 2, 'gender', 'en', 'Female'),
+    ('Student', 3, 'gender', 'en', 'Male'),
+    ('Student', 4, 'gender', 'en', 'Male'),
+    ('Student', 5, 'gender', 'en', 'Female'),
+    ('Student', 6, 'gender', 'en', 'Male'),
+    ('Student', 7, 'gender', 'en', 'Female'),
+    ('Student', 8, 'gender', 'en', 'Female'),
+    ('Student', 9, 'gender', 'en', 'Male'),
+    ('Student', 10, 'gender', 'en', 'Male'),
+    ('Student', 11, 'gender', 'en', 'Female'),
+    ('Student', 12, 'gender', 'en', 'Male'),
+    ('Student', 13, 'gender', 'en', 'Male'),
+    ('Student', 14, 'gender', 'en', 'Female'),
+    ('Student', 15, 'gender', 'en', 'Female'),
+    ('Student', 16, 'gender', 'en', 'Male'),
+    ('Student', 17, 'gender', 'en', 'Female'),
+    ('Student', 18, 'gender', 'en', 'Male'),
+    ('Student', 19, 'gender', 'en', 'Female'),
+    ('Student', 20, 'gender', 'en', 'Male');
+
+-- Dịch địa chỉ (addresses) - phường, quận, thành phố
+INSERT INTO translations (entity_type, entity_id, field_name, language_code, translated_value)
+VALUES
+    ('Address', 1, 'wardCommune', 'en', 'Ward 1'),
+    ('Address', 1, 'district', 'en', 'District 3'),
+    ('Address', 1, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 1, 'country', 'en', 'Vietnam'),
+
+    ('Address', 2, 'wardCommune', 'en', 'Ward 5'),
+    ('Address', 2, 'district', 'en', 'District 1'),
+    ('Address', 2, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 2, 'country', 'en', 'Vietnam'),
+
+    ('Address', 3, 'wardCommune', 'en', 'Ward 2'),
+    ('Address', 3, 'district', 'en', 'District 4'),
+    ('Address', 3, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 3, 'country', 'en', 'Vietnam'),
+
+    ('Address', 4, 'wardCommune', 'en', 'Ward 6'),
+    ('Address', 4, 'district', 'en', 'District 1'),
+    ('Address', 4, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 4, 'country', 'en', 'Vietnam'),
+
+    ('Address', 5, 'wardCommune', 'en', 'Ward 3'),
+    ('Address', 5, 'district', 'en', 'District 5'),
+    ('Address', 5, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 5, 'country', 'en', 'Vietnam'),
+
+    ('Address', 6, 'wardCommune', 'en', 'Ward 7'),
+    ('Address', 6, 'district', 'en', 'District 10'),
+    ('Address', 6, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 6, 'country', 'en', 'Vietnam'),
+
+    ('Address', 7, 'wardCommune', 'en', 'Ward 8'),
+    ('Address', 7, 'district', 'en', 'District 6'),
+    ('Address', 7, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 7, 'country', 'en', 'Vietnam'),
+
+    ('Address', 8, 'wardCommune', 'en', 'Ward 9'),
+    ('Address', 8, 'district', 'en', 'District 2'),
+    ('Address', 8, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 8, 'country', 'en', 'Vietnam'),
+
+    ('Address', 9, 'wardCommune', 'en', 'Ward 10'),
+    ('Address', 9, 'district', 'en', 'District 7'),
+    ('Address', 9, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 9, 'country', 'en', 'Vietnam'),
+
+    ('Address', 10, 'wardCommune', 'en', 'Ward 11'),
+    ('Address', 10, 'district', 'en', 'District 8'),
+    ('Address', 10, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 10, 'country', 'en', 'Vietnam'),
+
+    ('Address', 11, 'wardCommune', 'en', 'Ward 12'),
+    ('Address', 11, 'district', 'en', 'Tan Binh District'),
+    ('Address', 11, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 11, 'country', 'en', 'Vietnam'),
+
+    ('Address', 12, 'wardCommune', 'en', 'Ward 13'),
+    ('Address', 12, 'district', 'en', 'District 9'),
+    ('Address', 12, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 12, 'country', 'en', 'Vietnam'),
+
+    ('Address', 13, 'wardCommune', 'en', 'Ward 14'),
+    ('Address', 13, 'district', 'en', 'District 11'),
+    ('Address', 13, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 13, 'country', 'en', 'Vietnam'),
+
+    ('Address', 14, 'wardCommune', 'en', 'Ward 15'),
+    ('Address', 14, 'district', 'en', 'Binh Thanh District'),
+    ('Address', 14, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 14, 'country', 'en', 'Vietnam'),
+
+    ('Address', 15, 'wardCommune', 'en', 'Ward 16'),
+    ('Address', 15, 'district', 'en', 'Go Vap District'),
+    ('Address', 15, 'cityProvince', 'en', 'Ho Chi Minh City'),
+    ('Address', 15, 'country', 'en', 'Vietnam');
+


### PR DESCRIPTION
### This PR implements i18n support based on Accept-Language header.

### Key changes:
- Added translations table with entity and repository
- Created TranslationService to retrieve translations
- Implemented LanguageInterceptor to process language headers
- Updated services to fetch appropriate translations
- Enhanced mappers to display content in user's preferred language

### Note:
- Currently supports Vietnamese (default) and English.
- Test by sending requests with Accept-Language: en header for English content.